### PR TITLE
Fix preview tile URL

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ import os
 
 CORS_SEND_WILDCARD = True
 CACHE_MAX_AGE = int(os.environ.get("CACHE_MAX_AGE", '600'))
+TILES_URL_BASE = os.environ.get('TILES_URL_BASE')
 S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_PREFIX = os.environ.get("S3_PREFIX")
 METATILE_SIZE = int(os.environ.get("METATILE_SIZE", '4'))

--- a/config.py
+++ b/config.py
@@ -3,7 +3,6 @@ import os
 
 CORS_SEND_WILDCARD = True
 CACHE_MAX_AGE = int(os.environ.get("CACHE_MAX_AGE", '600'))
-SERVER_NAME = os.environ.get('SERVER_NAME')
 S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_PREFIX = os.environ.get("S3_PREFIX")
 METATILE_SIZE = int(os.environ.get("METATILE_SIZE", '4'))

--- a/server.py
+++ b/server.py
@@ -249,18 +249,6 @@ def handle_tile(tile_pixel_size, z, x, y, fmt):
 
 @app.route('/preview.html')
 def preview_html():
-    template_url = url_for(
-        'handle_tile',
-        tile_pixel_size='512',
-        z='111',
-        x='222',
-        y='333',
-        fmt='mvt',
-        _external=True,
-    )
-    template_url = template_url.replace('111', '{z}').replace('222', '{x}').replace('333', '{y}')
-
     return render_template(
         'preview.html',
-        tiles_template=template_url,
     )

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -45,7 +45,7 @@
                 ],
                 sources: {
                     mapzen: {
-                        url: '{{ tiles_template }}',
+                        url: '{{ config.get("TILES_URL_BASE", "") }}/mapzen/vector/v1/512/all/{z}/{x}/{y}.mvt',
                         url_subdomains: ['a', 'b', 'c', 'd'],
                         url_params: null
                     }


### PR DESCRIPTION
Use a setting instead of url_for() to construct the tile URL. I was running into problems with SERVER_NAME causing 404's with all the proxies in the mix.