### PR TITLE
Support requester pays S3 buckets for metatiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The important bits of configuration are set in `config.py` using environment var
 `S3_BUCKET` | Specifies the S3 bucket to use when requesting metatiles.
 `S3_PREFIX` | Specifies the (optional) S3 key prefix to use when requesting metatiles. Should not include trailing slash.
 `METATILE_SIZE` | The metatile size used when creating the metatiles you're reading from.
+`REQUESTER_PAYS` | A boolean flag in configuration for REQUESTER_PAYS. Set it to `true` to use a [requester pays](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) bucket for metatiles.
 
 ## Running locally
 

--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_PREFIX = os.environ.get("S3_PREFIX")
 METATILE_SIZE = int(os.environ.get("METATILE_SIZE", '4'))
 INCLUDE_HASH = os.environ.get("INCLUDE_HASH", 'true') == 'true'
+REQUESTER_PAYS = os.environ.get("REQUESTER_PAYS", 'false') == 'true'
 COMPRESS_MIMETYPES = [
     'application/x-protobuf',
     'application/json',

--- a/server.py
+++ b/server.py
@@ -120,6 +120,7 @@ def compute_key(prefix, layer, meta_tile, include_hash=True):
 def metatile_fetch(meta, cache_info):
     s3_key_prefix = current_app.config.get('S3_PREFIX')
     include_hash = current_app.config.get('INCLUDE_HASH')
+    requester_pays = current_app.config.get('REQUESTER_PAYS')
 
     s3_bucket = current_app.config.get('S3_BUCKET')
     s3_key = compute_key(s3_key_prefix, 'all', meta, include_hash)
@@ -135,6 +136,9 @@ def metatile_fetch(meta, cache_info):
 
     if cache_info.etag:
         get_params['IfNoneMatch'] = cache_info.etag
+
+    if requester_pays:
+        get_params['RequestPayer'] = 'requester'
 
     try:
         response = s3.get_object(**get_params)


### PR DESCRIPTION
Fixes #8

Adds a boolean flag in configuration for `REQUESTER_PAYS`. Set it to true to use a [requester pays](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) bucket for metatiles.