### PR TITLE
Overzoom fallback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The important bits of configuration are set in `config.py` using environment var
 `S3_BUCKET` | Specifies the S3 bucket to use when requesting metatiles.
 `S3_PREFIX` | Specifies the (optional) S3 key prefix to use when requesting metatiles. Should not include trailing slash.
 `METATILE_SIZE` | The metatile size used when creating the metatiles you're reading from.
+`METATILE_MAX_DETAIL_ZOOM` | (Optional) The zoom of the most detailed metatiles available. If present, this can be used to satisfy requests for larger tile sizes at zooms higher than are actually present by transparently falling back to "smaller" tile sizes.
 `REQUESTER_PAYS` | A boolean flag in configuration for REQUESTER_PAYS. Set it to `true` to use a [requester pays](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) bucket for metatiles.
 
 ## Running locally

--- a/config.py
+++ b/config.py
@@ -18,6 +18,7 @@ TILES_URL_BASE = os.environ.get('TILES_URL_BASE')
 S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_PREFIX = os.environ.get("S3_PREFIX")
 METATILE_SIZE = int(os.environ.get("METATILE_SIZE", '4'))
+METATILE_MAX_DETAIL_ZOOM = int(os.environ.get("METATILE_MAX_DETAIL_ZOOM")) if os.environ.get("METATILE_MAX_DETAIL_ZOOM") else None
 INCLUDE_HASH = os.environ.get("INCLUDE_HASH", 'true') == 'true'
 REQUESTER_PAYS = os.environ.get("REQUESTER_PAYS", 'false') == 'true'
 COMPRESS_MIMETYPES = [

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ import zipfile
 from cachetools import LFUCache, cached
 from collections import namedtuple
 from io import BytesIO
-from flask import Flask, current_app, make_response, render_template, request, url_for
+from flask import Flask, current_app, make_response, render_template, request, abort
 from flask_compress import Compress
 from flask_cors import CORS
 

--- a/server.py
+++ b/server.py
@@ -54,7 +54,8 @@ def size_to_zoom(size):
     return math.log(size, 2)
 
 
-def meta_and_offset(requested_tile, meta_size, tile_size):
+def meta_and_offset(requested_tile, meta_size, tile_size,
+                    metatile_max_detail_zoom=None):
     if not is_power_of_two(meta_size):
         raise ValueError("Metatile size %s is not a power of two" % meta_size)
     if not is_power_of_two(tile_size):
@@ -74,6 +75,19 @@ def meta_and_offset(requested_tile, meta_size, tile_size):
         meta = TileRequest(0, 0, 0, 'zip')
         offset = TileRequest(0, 0, 0, requested_tile.format)
     else:
+
+        # allows setting a maximum detail level beyond which all features are
+        # present in the tile and requests with tile_size larger than are
+        # available can be satisfied with "smaller" tiles that are present.
+        if metatile_max_detail_zoom and \
+           requested_tile.z - delta_z > metatile_max_detail_zoom:
+            # the call to min() is here to clamp the size of the offset - the
+            # idea being that it's better to request a metatile that isn't
+            # present and 404, rather than request one that is, pay the cost
+            # of unzipping it, and find it doesn't contain the offset.
+            delta_z = min(requested_tile.z - metatile_max_detail_zoom,
+                          int(meta_zoom))
+
         meta = TileRequest(
             requested_tile.z - delta_z,
             requested_tile.x >> delta_z,
@@ -220,6 +234,7 @@ def handle_tile(tile_pixel_size, z, x, y, fmt):
         requested_tile,
         current_app.config.get('METATILE_SIZE'),
         tile_size,
+        metatile_max_detail_zoom=current_app.config.get('METATILE_MAX_DETAIL_ZOOM'),
     )
 
     request_cache_info = CacheInfo(

--- a/zappa_settings.json.example
+++ b/zappa_settings.json.example
@@ -14,7 +14,8 @@
             "S3_PREFIX": "20171221",
             "S3_BUCKET": "vector-tiles-prod",
             "REQUESTER_PAYS": "true",
-            "METATILE_SIZE": "4"
+            "METATILE_SIZE": "4",
+            "METATILE_MAX_DETAIL_ZOOM": "14"
         }
     },
     "prod": {
@@ -28,7 +29,8 @@
             "S3_PREFIX": "20171221",
             "S3_BUCKET": "vector-tiles-prod",
             "REQUESTER_PAYS": "true",
-            "METATILE_SIZE": "4"
+            "METATILE_SIZE": "4",
+            "METATILE_MAX_DETAIL_ZOOM": "14"
         }
     }
 }


### PR DESCRIPTION
This adds support for overzoom fallback, i.e: returning a "smaller" tile than was requested when the tile is already at the maximum detail level. This is enabled by providing the `METATILE_MAX_DETAIL_ZOOM` environment variable, or disabled by omitting it.