### PR TITLE
Use flask-boto3 to reduce time spent building S3 connection

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,8 +13,8 @@ zappa = "*"
 [packages]
 
 flask = "*"
-flask-cors = "*"
-flask-compress = "*"
-"boto3" = "*"
-python-dateutil = "*"
+"flask-boto3" = "*"
 flask-caching = "*"
+flask-compress = "*"
+flask-cors = "*"
+python-dateutil = "*"

--- a/config.py
+++ b/config.py
@@ -15,6 +15,7 @@ CACHE_MAX_AGE = int(os.environ.get("CACHE_MAX_AGE", '1200'))
 SHARED_CACHE_MAX_AGE = int(os.environ.get("SHARED_CACHE_MAX_AGE", '600'))
 
 TILES_URL_BASE = os.environ.get('TILES_URL_BASE')
+BOTO3_SERVICES = ['s3']
 S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_PREFIX = os.environ.get("S3_PREFIX")
 METATILE_SIZE = int(os.environ.get("METATILE_SIZE", '4'))


### PR DESCRIPTION
Instead of calling `boto3.client('s3')` (which seems to set up a new SSL connection) for each tile when getting the metatile, set it up once at application start and store it in the Flask application context using [`flask-boto3`](https://github.com/Ketouem/flask-boto3).

In testing this doesn't seem to actually help all that much, but I'm going to merge it in and fiddle with xray some more.