### PR TITLE
Zoom zero tile substitution

### DIFF
--- a/server.py
+++ b/server.py
@@ -50,8 +50,6 @@ CacheInfo = namedtuple('CacheInfo', ['last_modified', 'etag'])
 StorageResponse = namedtuple('StorageResponse', ['data', 'cache_info'])
 
 
-
-
 class MetatileNotModifiedException(Exception):
     pass
 
@@ -93,6 +91,9 @@ def meta_and_offset(requested_tile, meta_size, tile_size,
 
     delta_z = int(meta_zoom - tile_zoom)
 
+    # clip the top of the range, as we don't ever have tiles with negative
+    # zooms. this might change the effective delta between the zoom level of
+    # the request and the zoom level of the metatile.
     if requested_tile.z < delta_z:
         meta = TileRequest(0, 0, 0, 'zip')
         offset = TileRequest(0, 0, 0, requested_tile.format)
@@ -116,12 +117,14 @@ def meta_and_offset(requested_tile, meta_size, tile_size,
             requested_tile.y >> delta_z,
             'zip',
         )
-        offset = TileRequest(
-            requested_tile.z - meta.z,
-            requested_tile.x - (meta.x << delta_z),
-            requested_tile.y - (meta.y << delta_z),
-            requested_tile.format,
-        )
+
+    actual_delta_z = requested_tile.z - meta.z
+    offset = TileRequest(
+        actual_delta_z,
+        requested_tile.x - (meta.x << actual_delta_z),
+        requested_tile.y - (meta.y << actual_delta_z),
+        requested_tile.format,
+    )
 
     return meta, offset
 

--- a/server.py
+++ b/server.py
@@ -4,7 +4,6 @@ import dateutil.parser
 import hashlib
 import logging
 import math
-import sys
 import time
 import zipfile
 from collections import namedtuple

--- a/server.py
+++ b/server.py
@@ -96,7 +96,6 @@ def meta_and_offset(requested_tile, meta_size, tile_size,
     # the request and the zoom level of the metatile.
     if requested_tile.z < delta_z:
         meta = TileRequest(0, 0, 0, 'zip')
-        offset = TileRequest(0, 0, 0, requested_tile.format)
     else:
 
         # allows setting a maximum detail level beyond which all features are

--- a/tests.py
+++ b/tests.py
@@ -104,6 +104,29 @@ class MetatileTestCase(unittest.TestCase):
         self.assertTileEquals(TileRequest(16, 0, 0, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
 
+    def test_zoom_zero(self):
+        from server import meta_and_offset
+
+        # check that when the metatile size is larger (e.g: 8), we can still
+        # access the low zoom tiles 0-3.
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 'json'), 8, 2)
+        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
+        self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
+
+        meta, offset = meta_and_offset(TileRequest(1, 0, 1, 'json'), 8, 2)
+        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
+        self.assertTileEquals(TileRequest(1, 0, 1, 'json'), offset)
+
+        meta, offset = meta_and_offset(TileRequest(2, 1, 3, 'json'), 8, 2)
+        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
+        self.assertTileEquals(TileRequest(2, 1, 3, 'json'), offset)
+
+        # only once the offset exceeds the metatile size (at the request tile
+        # size) does it start to shift down zooms.
+        meta, offset = meta_and_offset(TileRequest(3, 2, 7, 'json'), 8, 2)
+        self.assertTileEquals(TileRequest(1, 0, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(2, 2, 3, 'json'), offset)
+
     def test_compute_key(self):
         from server import compute_key
 


### PR DESCRIPTION
Use "lower zoom" tiles within the zoom 0 metatile as substitutes for lower zoom tiles.

For example, if a we have a global build with metatile size 8x8, this means that the metatile zoom offset is 3, so the 256px tiles in the `0/0/0` metatile are actually tiles at zoom level 3. Changes [requested in `tilequeue`](https://github.com/tilezen/tilequeue/pull/342) would mean generating the tiles at lower zoom levels too, allowing us to use the `+0/0/0` offset in the `0/0/0` metatile to respond to the `0/0/0` request.

This approach means we'll always be able to answer a request for at least one tile size at _coordinate zoom_ 0 (i.e: a tile covering the whole world). The _nominal zoom_ will depend on the tile size which is configured. If we configure 512px tiles, then `0/0/0` will be a nominal zoom 1 tile.
