### PR TITLE
Configure key hash prefix

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ name = "pypi"
 [dev-packages]
 
 zappa = "*"
-
+futures = {version = "*", markers="python_version < '3.0'"}
 
 [packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ zappa = "*"
 
 [packages]
 
+enum34 = {version = "*", markers="python_version < '3.4'"}
 flask = "*"
 flask-caching = "*"
 flask-compress = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "91fc9c3b1988a535b4db63e3eef3da940094dfc55fdb9e4f48d314f598e5da87"
+            "sha256": "bbcdcda9d1d1a84baa44b4fd441890dff42897c220c900546480a41e31a1ec0c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -191,7 +191,8 @@
         },
         "futures": {
             "hashes": [],
-            "markers": "python_version < '3' and python_version >= '2.6'",
+            "index": "pypi",
+            "markers": "python_version < '3.0'",
             "version": "==3.2.0"
         },
         "hjson": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "89b61f858b80308ba201075d535f46fc5c5e07aa87ca2bcfd881aac2f9c5cb73"
+            "sha256": "91fc9c3b1988a535b4db63e3eef3da940094dfc55fdb9e4f48d314f598e5da87"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -21,32 +21,47 @@
             ],
             "version": "==6.7"
         },
+        "enum34": {
+            "hashes": [
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+            ],
+            "index": "pypi",
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.6"
+        },
         "flask": {
             "hashes": [
-                "sha256:0749df235e3ff61ac108f69ac178c9770caeaccad2509cb762ce1f65570a8856",
-                "sha256:49f44461237b69ecd901cc7ce66feea0319b9158743dd27a2899962ab214dac1"
+                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
+                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
             ],
-            "version": "==0.12.2"
+            "index": "pypi",
+            "version": "==1.0.2"
         },
         "flask-caching": {
             "hashes": [
-                "sha256:21236d2b4567deb9fc95e474a604602097189e834629c24f4d62937abc963636"
+                "sha256:44fe827c6cc519d48fb0945fa05ae3d128af9a98f2a6e71d4702fd512534f227",
+                "sha256:e34f24631ba240e09fe6241e1bf652863e0cff06a1a94598e23be526bc2e4985"
             ],
-            "version": "==1.3.3"
+            "index": "pypi",
+            "version": "==1.4.0"
         },
         "flask-compress": {
             "hashes": [
                 "sha256:468693f4ddd11ac6a41bca4eb5f94b071b763256d54136f77957cfee635badb3"
             ],
+            "index": "pypi",
             "version": "==1.4.0"
         },
         "flask-cors": {
             "hashes": [
-                "sha256:55eb3864b4290f939ff19a2250fcb47d8c0f63d250c6780b922629299d011ec8",
-                "sha256:62ebc5ad80dc21ca0ea9f57466c2c74e24a62274af890b391790c260eb7b754b",
-                "sha256:ac4b81b3d90f5f18714c995c807f94501df8c9bbc22ef4261c1cd850748c3850"
+                "sha256:e4c8fc15d3e4b4cce6d3b325f2bab91e0e09811a61f50d7a53493bc44242a4f1",
+                "sha256:ecc016c5b32fa5da813ec8d272941cfddf5f6bba9060c405a70285415cbf24c9"
             ],
-            "version": "==3.0.3"
+            "index": "pypi",
+            "version": "==3.0.6"
         },
         "itsdangerous": {
             "hashes": [
@@ -69,16 +84,18 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:3220490fb9741e2342e1cf29a503394fdac874bc39568288717ee67047ff29df",
-                "sha256:9d8074be4c993fbe4947878ce593052f71dac82932a677d49194d8ce9778002e"
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
             ],
-            "version": "==2.7.2"
+            "index": "pypi",
+            "version": "==2.7.3"
         },
         "redis": {
             "hashes": [
                 "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
                 "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
             ],
+            "index": "pypi",
             "version": "==2.10.6"
         },
         "six": {
@@ -99,38 +116,38 @@
     "develop": {
         "argcomplete": {
             "hashes": [
-                "sha256:74e34bbd5bcb902e67a39e2edf1b1ef3dcb504a6a1d4cd23ce3949f25c4aad55",
-                "sha256:d6ea272a93bb0387f758def836e73c36fff0c54170258c212de3e84f7db8d5ed"
+                "sha256:c079ceb0b72d4d4e03531ed77e6071babb9d42c3f790d7def2c41295b4990b44",
+                "sha256:d97b7f3cfaa4e494ad59ed6d04c938fc5ed69b590bd8f53274e258fb1119bd1b"
             ],
-            "version": "==1.9.2"
+            "version": "==1.9.3"
         },
         "base58": {
             "hashes": [
-                "sha256:97cb4dcbc7a81afb802f41033d5562b6c48633426a67bf41e4cad186f581158c",
-                "sha256:aafdd84adf1fbd073eb2fd7f7266d7bd9f2423ee1000ee61cd021b97ed359f39"
+                "sha256:93fa54b615a7c406701a56e3d11c3a5defdbcd371f36c0452f1ac77623e42d16",
+                "sha256:c5fe8b00fab798b4a3393da6235bdecb143db505833e3f979890f7c6fc99f651"
             ],
-            "version": "==0.2.4"
+            "version": "==1.0.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:13ad5f64a247d655a27dca83274588e9d14cba61b38d3d4fd2b011b7197d88dd",
-                "sha256:a56b21efbc994580fc9cef454f0f949745c152326f939aed6609d1c47b2a0f8f"
+                "sha256:b5ae96cc8d24530298e01a9a77a4982e4f466e1313f21703b2e282eff2ba6292",
+                "sha256:ded0cc0a9a58a9c58d2e95d76fa17a559a1c1ebae3a9c70186c6e8b985357f74"
             ],
-            "version": "==1.7.4"
+            "version": "==1.7.78"
         },
         "botocore": {
             "hashes": [
-                "sha256:5602738392ecde5c02a06a3b02de07171f440a44cdfef0aadff4b59567359607",
-                "sha256:77f2869b8c27afbab78b72ce6b74c75923421f364c7a0153ac1a38858c59cd91"
+                "sha256:7af71a263f6512d96548283a225e0cdedcbe985cc36dec9bb18d7accfe1e8a88",
+                "sha256:fd4dca165c7ef1e6d0721af433b50b1459a78ee917fee68d207dca703aabf71f"
             ],
-            "version": "==1.10.4"
+            "version": "==1.10.78"
         },
         "certifi": {
             "hashes": [
-                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
-                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
+                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
             ],
-            "version": "==2018.1.18"
+            "version": "==2018.8.13"
         },
         "cfn-flip": {
             "hashes": [
@@ -172,6 +189,11 @@
             ],
             "version": "==0.16.0"
         },
+        "futures": {
+            "hashes": [],
+            "markers": "python_version < '3' and python_version >= '2.6'",
+            "version": "==3.2.0"
+        },
         "hjson": {
             "hashes": [
                 "sha256:1d1727faa6aaef2973921877125a3ab7c5f6d34b93233179d01770f41fab51f9"
@@ -180,10 +202,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "jmespath": {
             "hashes": [
@@ -201,9 +223,9 @@
         },
         "lambda-packages": {
             "hashes": [
-                "sha256:cbe35f0642206a4adfb4855f80d55e273bdacc083011eba5f9ed3beedf0879fa"
+                "sha256:b5e3b81ecef5f7c1b0903b5c40813536ba2343a33868a567e4e4ff1e26243406"
             ],
-            "version": "==0.19.0"
+            "version": "==0.20.0"
         },
         "placebo": {
             "hashes": [
@@ -213,10 +235,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:3220490fb9741e2342e1cf29a503394fdac874bc39568288717ee67047ff29df",
-                "sha256:9d8074be4c993fbe4947878ce593052f71dac82932a677d49194d8ce9778002e"
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
             ],
-            "version": "==2.7.2"
+            "index": "pypi",
+            "version": "==2.7.3"
         },
         "python-slugify": {
             "hashes": [
@@ -227,29 +250,23 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
                 "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
                 "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
-                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
-                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
                 "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
                 "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
-                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
                 "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
-                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
                 "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
                 "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
-                "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
                 "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
             ],
             "version": "==3.12"
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "version": "==2.18.4"
+            "version": "==2.19.1"
         },
         "s3transfer": {
             "hashes": [
@@ -280,9 +297,9 @@
         },
         "troposphere": {
             "hashes": [
-                "sha256:e15e2470fe4f02a5c1b70ccd552b09ac664acfff0de74cd4464acf8e6039e118"
+                "sha256:aecc32359326634c9911ae4bea05d308822b827787926dcc038c153410ce380b"
             ],
-            "version": "==2.2.1"
+            "version": "==2.3.1"
         },
         "unidecode": {
             "hashes": [
@@ -293,10 +310,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "version": "==1.22"
+            "markers": "python_version >= '2.6' and python_version < '4' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "version": "==1.23"
         },
         "werkzeug": {
             "hashes": [
@@ -307,10 +325,11 @@
         },
         "wheel": {
             "hashes": [
-                "sha256:1ae8153bed701cb062913b72429bcf854ba824f973735427681882a688cb55ce",
-                "sha256:9cdc8ab2cc9c3c2e2727a4b67c22881dbb0e1c503d592992594c5e131c867107"
+                "sha256:0a2e54558a0628f2145d2fc822137e322412115173e8a2ddbe1c9024338ae83c",
+                "sha256:80044e51ec5bbf6c894ba0bc48d26a8c20a9ba629f4ca19ea26ecfcf87685f5f"
             ],
-            "version": "==0.31.0"
+            "markers": "python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "version": "==0.31.1"
         },
         "wsgi-request-logger": {
             "hashes": [
@@ -320,10 +339,11 @@
         },
         "zappa": {
             "hashes": [
-                "sha256:827c2c1cc84790674476a98773601b924a2b4f3b0b81684571cd034326231158",
-                "sha256:cf4654dfa7cd8777403ea2e379139b126c7e47943edb4e5441bb222a555a1aff"
+                "sha256:6b303a82698035d465e3426008a355b17733204c205e6efab7b4168ac84eb918",
+                "sha256:b4d310821d19c773f9d1457fa00287c154097c72e502d71f0879cb765a2130b4"
             ],
-            "version": "==0.45.1"
+            "index": "pypi",
+            "version": "==0.46.2"
         }
     }
 }

--- a/config.py
+++ b/config.py
@@ -29,7 +29,8 @@ S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_PREFIX = os.environ.get("S3_PREFIX")
 METATILE_SIZE = int(os.environ.get("METATILE_SIZE", '4'))
 METATILE_MAX_DETAIL_ZOOM = int(os.environ.get("METATILE_MAX_DETAIL_ZOOM")) if os.environ.get("METATILE_MAX_DETAIL_ZOOM") else None
-INCLUDE_HASH = os.environ.get("INCLUDE_HASH", 'true') == 'true'
+INCLUDE_HASH = os.environ.get("INCLUDE_HASH") == 'true' if os.environ.get("INCLUDE_HASH") else None
+KEY_FORMAT_TYPE = os.environ.get("KEY_FORMAT_TYPE")
 REQUESTER_PAYS = os.environ.get("REQUESTER_PAYS", 'false') == 'true'
 
 COMPRESS_MIMETYPES = [

--- a/server.py
+++ b/server.py
@@ -7,12 +7,18 @@ import math
 import time
 import zipfile
 from collections import namedtuple
-from enum import Enum
 from io import BytesIO
 from flask import Blueprint, Flask, current_app, make_response, render_template, request, abort
 from flask_caching import Cache
 from flask_compress import Compress
 from flask_cors import CORS
+
+# make compatible with both 3.4+, which has enum built in, and <=3.3 which
+# doesn't.
+try:
+    from enum import Enum
+except ImportError:
+    from enum34 import Enum
 
 
 tile_bp = Blueprint('tiles', __name__)

--- a/tests.py
+++ b/tests.py
@@ -4,10 +4,10 @@ from server import TileRequest
 
 class MetatileTestCase(unittest.TestCase):
     def assertTileEquals(self, expected, actual):
-        self.assertEquals(expected.z, actual.z)
-        self.assertEquals(expected.x, actual.x)
-        self.assertEquals(expected.y, actual.y)
-        self.assertEquals(expected.format, actual.format)
+        self.assertEqual(expected.z, actual.z)
+        self.assertEqual(expected.x, actual.x)
+        self.assertEqual(expected.y, actual.y)
+        self.assertEqual(expected.format, actual.format)
 
     def test_is_power_of_two(self):
         from server import is_power_of_two
@@ -24,9 +24,9 @@ class MetatileTestCase(unittest.TestCase):
     def test_size_to_zoom(self):
         from server import size_to_zoom
 
-        self.assertEquals(0.0, size_to_zoom(1))
-        self.assertEquals(1.0, size_to_zoom(2))
-        self.assertEquals(2.0, size_to_zoom(4))
+        self.assertEqual(0.0, size_to_zoom(1))
+        self.assertEqual(1.0, size_to_zoom(2))
+        self.assertEqual(2.0, size_to_zoom(4))
 
     def test_meta_and_offset(self):
         from server import meta_and_offset
@@ -132,16 +132,16 @@ class MetatileTestCase(unittest.TestCase):
 
         t = TileRequest(13, 4008, 3973, 'zip')
 
-        self.assertEquals(
+        self.assertEqual(
             'abc/c1315/all/13/4008/3973.zip',
             compute_key('abc', 'all', t, KeyFormatType.PREFIX_HASH))
-        self.assertEquals(
+        self.assertEqual(
             'c1315/all/13/4008/3973.zip',
             compute_key('', 'all', t, KeyFormatType.PREFIX_HASH))
-        self.assertEquals(
+        self.assertEqual(
             'all/13/4008/3973.zip',
             compute_key('', 'all', t, KeyFormatType.NO_HASH))
-        self.assertEquals(
+        self.assertEqual(
             'c1315/abc/all/13/4008/3973.zip',
             compute_key('abc', 'all', t, KeyFormatType.HASH_PREFIX))
 

--- a/tests.py
+++ b/tests.py
@@ -128,19 +128,22 @@ class MetatileTestCase(unittest.TestCase):
         self.assertTileEquals(TileRequest(2, 2, 3, 'json'), offset)
 
     def test_compute_key(self):
-        from server import compute_key
+        from server import compute_key, KeyFormatType
 
         t = TileRequest(13, 4008, 3973, 'zip')
 
         self.assertEquals(
             'abc/c1315/all/13/4008/3973.zip',
-            compute_key('abc', 'all', t, True))
+            compute_key('abc', 'all', t, KeyFormatType.PREFIX_HASH))
         self.assertEquals(
             'c1315/all/13/4008/3973.zip',
-            compute_key('', 'all', t, True))
+            compute_key('', 'all', t, KeyFormatType.PREFIX_HASH))
         self.assertEquals(
             'all/13/4008/3973.zip',
-            compute_key('', 'all', t, False))
+            compute_key('', 'all', t, KeyFormatType.NO_HASH))
+        self.assertEquals(
+            'c1315/abc/all/13/4008/3973.zip',
+            compute_key('abc', 'all', t, KeyFormatType.HASH_PREFIX))
 
 
 class HandleTileTestCase(unittest.TestCase):


### PR DESCRIPTION
Added a `KeyFormatType` enum, configurable via a `KEY_FORMAT_TYPE` environment variable, which configures whether it's no-hash, prefix-hash or hash-prefix order for the S3 keys.

For compatibility with https://github.com/tilezen/tilequeue/pull/344.