### PR TITLE
Configurable layer parameter for S3 keys.

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ TILES_URL_BASE = os.environ.get('TILES_URL_BASE')
 TILES_PREVIEW_API_KEY = os.environ.get('TILES_PREVIEW_API_KEY')
 S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_PREFIX = os.environ.get("S3_PREFIX")
+S3_LAYER = os.environ.get("S3_LAYER", "all")
 METATILE_SIZE = int(os.environ.get("METATILE_SIZE", '4'))
 METATILE_MAX_DETAIL_ZOOM = int(os.environ.get("METATILE_MAX_DETAIL_ZOOM")) if os.environ.get("METATILE_MAX_DETAIL_ZOOM") else None
 INCLUDE_HASH = os.environ.get("INCLUDE_HASH") == 'true' if os.environ.get("INCLUDE_HASH") else None

--- a/tests.py
+++ b/tests.py
@@ -145,6 +145,13 @@ class MetatileTestCase(unittest.TestCase):
             'c1315/abc/all/13/4008/3973.zip',
             compute_key('abc', 'all', t, KeyFormatType.HASH_PREFIX))
 
+        # test for "new format" hashed path where layer isn't included
+        # since https://github.com/tilezen/tilequeue/pull/344
+        t2 = TileRequest(10, 14, 719, 'zip')
+        self.assertEqual(
+            '27584/180723/10/14/719.zip',
+            compute_key('180723', '', t2, KeyFormatType.HASH_PREFIX))
+
 
 class HandleTileTestCase(unittest.TestCase):
     def test_handle_tile_storage_hit(self):


### PR DESCRIPTION
This allows us to match a code change made in https://github.com/tilezen/tilequeue/pull/344, where the layer (and leading slash) are not longer part of the hashed string to make the S3 key.

Added tests to make sure we're conforming to the new way of calculating hashes and still backwards compatible with the old way.
