### PR TITLE
Add a land cover route and support for tapalcatl2 archives

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,7 +39,7 @@ COMPRESS_MIMETYPES = [
     'application/json',
 ]
 
-# Land cover layer is built using Tapalcatl2 archives that require a bit of extra configuration:
+# Landcover layer is built using Tapalcatl2 archives that require a bit of extra configuration:
 # The maximum zoom level for the land cover data is different than the vector tiles
 LANDCOVER_MAX_ZOOM = 13
 # Tapalcatl2 archives are "materialized" at particular zoom levels at build time.

--- a/config.py
+++ b/config.py
@@ -38,3 +38,13 @@ COMPRESS_MIMETYPES = [
     'application/x-protobuf',
     'application/json',
 ]
+
+# Land cover layer is built using Tapalcatl2 archives that require a bit of extra configuration:
+# The maximum zoom level for the land cover data is different than the vector tiles
+LANDCOVER_MAX_ZOOM = 13
+# Tapalcatl2 archives are "materialized" at particular zoom levels at build time.
+# These are the zooms we picked when building the land cover layer
+LANDCOVER_MATERIALIZED_ZOOMS = [0, 7]
+# Tapalcatl2 archives can contain multiple neighboring tiles to form a "metatile"
+# THe land cover build used a metatile size of 1
+LANDCOVER_METATILE_SIZE = 1

--- a/config.py
+++ b/config.py
@@ -40,11 +40,11 @@ COMPRESS_MIMETYPES = [
 ]
 
 # Landcover layer is built using Tapalcatl2 archives that require a bit of extra configuration:
-# The maximum zoom level for the land cover data is different than the vector tiles
+# The maximum zoom level for the landcover data is different than the vector tiles
 LANDCOVER_MAX_ZOOM = 13
 # Tapalcatl2 archives are "materialized" at particular zoom levels at build time.
-# These are the zooms we picked when building the land cover layer
+# These are the zooms we picked when building the landcover layer
 LANDCOVER_MATERIALIZED_ZOOMS = [0, 7]
 # Tapalcatl2 archives can contain multiple neighboring tiles to form a "metatile"
-# THe land cover build used a metatile size of 1
+# THe landcover build used a metatile size of 1
 LANDCOVER_METATILE_SIZE = 1

--- a/server.py
+++ b/server.py
@@ -450,9 +450,6 @@ def handle_landcover_tile(z, x, y, fmt, tile_pixel_size=None):
 
     requested_tile = TileRequest(z, x, y, tile_size, fmt)
 
-    t2_materialized_zooms = [0, 7]
-    t2_metatile_size = 1
-
     (meta, offset) = t2_meta_and_offset(
         requested_tile,
         current_app.config.get('LANDCOVER_MATERIALIZED_ZOOMS'),

--- a/server.py
+++ b/server.py
@@ -80,20 +80,20 @@ def size_to_zoom(size):
     return math.log(size, 2)
 
 
-def meta_and_offset(requested_tile, meta_size, tile_size,
+def meta_and_offset(requested_tile, meta_size,
                     metatile_max_detail_zoom=None):
     if not is_power_of_two(meta_size):
         raise ValueError("Metatile size %s is not a power of two" % meta_size)
-    if not is_power_of_two(tile_size):
-        raise ValueError("Tile size %s is not a power of two" % tile_size)
+    if not is_power_of_two(requested_tile.scale):
+        raise ValueError("Tile size %s is not a power of two" % requested_tile.scale)
 
     meta_zoom = size_to_zoom(meta_size)
-    tile_zoom = size_to_zoom(tile_size)
+    tile_zoom = size_to_zoom(requested_tile.scale)
 
     if tile_zoom > meta_zoom:
         raise ValueError(
             "Tile size must not be greater than metatile size, "
-            "but %d > %d." % (tile_size, meta_size))
+            "but %d > %d." % (requested_tile.scale, meta_size))
 
     delta_z = int(meta_zoom - tile_zoom)
 
@@ -322,7 +322,6 @@ def handle_tile(z, x, y, fmt, tile_pixel_size=None):
     meta, offset = meta_and_offset(
         requested_tile,
         current_app.config.get('METATILE_SIZE'),
-        tile_size,
         metatile_max_detail_zoom=current_app.config.get('METATILE_MAX_DETAIL_ZOOM'),
     )
 

--- a/server.py
+++ b/server.py
@@ -383,7 +383,10 @@ def tilejson(fmt, tile_pixel_size=None):
 
 def t2_meta_and_offset(requested_tile, materialized_zooms, metatile_size):
     # Find the materialized zoom that holds this tile
-    mz = next(x for x in sorted(materialized_zooms, reverse=True) if x <= requested_tile.z)
+    try:
+        mz = next(z for z in sorted(materialized_zooms, reverse=True) if z <= requested_tile.z)
+    except StopIteration as e:
+        raise ValueError("Couldn't find materialized zoom for requested tile %s" % requested_tile)
 
     # Find the tile at the materialized zoom that holds the requested tile
     dz = requested_tile.z - mz

--- a/server.py
+++ b/server.py
@@ -51,7 +51,7 @@ MIME_TYPES = {
     "mvtb": "application/x-protobuf",
     "topojson": "application/json",
 }
-TileRequest = namedtuple('TileRequest', ['z', 'x', 'y', 'format'])
+TileRequest = namedtuple('TileRequest', ['z', 'x', 'y', 'scale', 'format'])
 CacheInfo = namedtuple('CacheInfo', ['last_modified', 'etag'])
 StorageResponse = namedtuple('StorageResponse', ['data', 'cache_info'])
 
@@ -101,7 +101,7 @@ def meta_and_offset(requested_tile, meta_size, tile_size,
     # zooms. this might change the effective delta between the zoom level of
     # the request and the zoom level of the metatile.
     if requested_tile.z < delta_z:
-        meta = TileRequest(0, 0, 0, 'zip')
+        meta = TileRequest(0, 0, 0, 1, 'zip')
     else:
 
         # allows setting a maximum detail level beyond which all features are
@@ -120,6 +120,7 @@ def meta_and_offset(requested_tile, meta_size, tile_size,
             requested_tile.z - delta_z,
             requested_tile.x >> delta_z,
             requested_tile.y >> delta_z,
+            1,
             'zip',
         )
 
@@ -128,6 +129,7 @@ def meta_and_offset(requested_tile, meta_size, tile_size,
         actual_delta_z,
         requested_tile.x - (meta.x << actual_delta_z),
         requested_tile.y - (meta.y << actual_delta_z),
+        requested_tile.scale,
         requested_tile.format,
     )
 
@@ -254,7 +256,7 @@ def metatile_fetch(meta, cache_info):
             raise MetatileNotModifiedException()
         elif error_code == 'NoSuchKey':
             raise MetatileNotFoundException(
-                "No tile found at s3://%s/%s" % (s3_bucket, s3_key)
+                "No metatile found at s3://%s/%s" % (s3_bucket, s3_key)
             )
         else:
             raise UnknownMetatileException(
@@ -299,8 +301,8 @@ def retrieve_tile(meta, offset, cache_info):
     )
 
 
-def is_valid_tile_request(z, x, y):
-    return (0 <= z < 17) and (0 <= x < 2**z) and (0 <= y < 2**z)
+def is_valid_tile_request(z, x, y, max_zoom=17):
+    return (0 <= z < max_zoom) and (0 <= x < 2**z) and (0 <= y < 2**z)
 
 
 @tile_bp.route('/tilezen/vector/v1/<int:tile_pixel_size>/all/<int:z>/<int:x>/<int:y>.<fmt>')
@@ -313,10 +315,9 @@ def handle_tile(z, x, y, fmt, tile_pixel_size=None):
     tile_size = tile_pixel_size / 256
     if tile_size != int(tile_size):
         return abort(400, "Invalid tile size. %s is not a multiple of 256." % tile_pixel_size)
-
-    requested_tile = TileRequest(z, x, y, fmt)
-
     tile_size = int(tile_size)
+
+    requested_tile = TileRequest(z, x, y, tile_size, fmt)
 
     meta, offset = meta_and_offset(
         requested_tile,
@@ -379,6 +380,112 @@ def tilejson(fmt, tile_pixel_size=None):
     resp = make_response(rendered_template)
     resp.headers = {'Content-Type': 'application/json'}
     return resp
+
+
+def t2_meta_and_offset(requested_tile, materialized_zooms, metatile_size):
+    # Find the materialized zoom that holds this tile
+    mz = next(x for x in sorted(materialized_zooms, reverse=True) if x <= requested_tile.z)
+
+    # Find the tile at the materialized zoom that holds the requested tile
+    dz = requested_tile.z - mz
+    mx = requested_tile.x >> dz
+    my = requested_tile.y >> dz
+    mx -= mx % metatile_size
+    my -= my % metatile_size
+
+    meta = TileRequest(mz, mx, my, 1, 'zip')
+
+    # Build the key for the tile inside the archive
+    offset = requested_tile
+
+    return meta, offset
+
+
+def t2_extract_tile(metatile_bytes, offset):
+    data = BytesIO(metatile_bytes)
+    z = zipfile.ZipFile(data, 'r')
+
+    offset_key = '{zoom}/{x}/{y}{scale}.{format}'.format(
+        zoom=offset.z,
+        x=offset.x,
+        y=offset.y,
+        scale='' if offset.scale < 2 else '@%dx' % offset.scale,
+        format=offset.format,
+    )
+
+    try:
+        return z.read(offset_key)
+    except KeyError as e:
+        raise TileNotFoundInMetatile("Couldn't find tile %s in metatile" % offset_key)
+
+
+def t2_retrieve_tile(meta, offset, cache_info):
+    metatile_data = metatile_fetch(meta, cache_info)
+    tile_data = t2_extract_tile(metatile_data.data, offset)
+
+    return StorageResponse(
+        data=tile_data,
+        cache_info=CacheInfo(
+            last_modified=metatile_data.cache_info.last_modified,
+            etag=metatile_data.cache_info.etag,
+        )
+    )
+
+
+@tile_bp.route('/tilezen/landcover/v1/<int:tile_pixel_size>/all/<int:z>/<int:x>/<int:y>.<fmt>')
+@tile_bp.route('/tilezen/landcover/v1/all/<int:z>/<int:x>/<int:y>.<fmt>')
+def handle_landcover_tile(z, x, y, fmt, tile_pixel_size=None):
+    if not is_valid_tile_request(z, x, y, max_zoom=current_app.config.get('LANDCOVER_MAX_ZOOM')):
+        return abort(400, "Requested tile out of range.")
+
+    tile_pixel_size = tile_pixel_size or 256
+    tile_size = tile_pixel_size / 256
+    if tile_size != int(tile_size):
+        return abort(400, "Invalid tile size. %s is not a multiple of 256." % tile_pixel_size)
+    if tile_size != 2:
+        return abort(400, "Landcover only supports 512 tile size.")
+    tile_size = int(tile_size)
+
+    requested_tile = TileRequest(z, x, y, tile_size, fmt)
+
+    t2_materialized_zooms = [0, 7]
+    t2_metatile_size = 1
+
+    (meta, offset) = t2_meta_and_offset(
+        requested_tile,
+        current_app.config.get('LANDCOVER_MATERIALIZED_ZOOMS'),
+        current_app.config.get('LANDCOVER_METATILE_SIZE'),
+    )
+
+    request_cache_info = CacheInfo(
+        last_modified=parse_header_time(request.headers.get('If-Modified-Since')),
+        etag=request.headers.get('If-None-Match'),
+    )
+
+    try:
+        storage_result = t2_retrieve_tile(meta, offset, request_cache_info)
+
+        response = make_response(storage_result.data)
+        response.content_type = MIME_TYPES.get(fmt)
+        response.last_modified = storage_result.cache_info.last_modified
+        response.cache_control.public = True
+        response.cache_control.max_age = current_app.config.get("CACHE_MAX_AGE")
+        if current_app.config.get("SHARED_CACHE_MAX_AGE"):
+            response.cache_control.s_maxage = current_app.config.get("SHARED_CACHE_MAX_AGE")
+        response.set_etag(storage_result.cache_info.etag)
+        return response
+
+    except MetatileNotFoundException:
+        current_app.logger.exception("Could not find metatile")
+        return "Metatile not found", 404
+    except TileNotFoundInMetatile:
+        current_app.logger.exception("Could not find tile in metatile")
+        return "Tile not found", 404
+    except MetatileNotModifiedException:
+        return "", 304
+    except UnknownMetatileException:
+        current_app.logger.exception("Error fetching metatile")
+        return "Metatile fetch problem", 500
 
 
 @tile_bp.route('/health_check')

--- a/tests.py
+++ b/tests.py
@@ -39,7 +39,7 @@ class MetatileTestCase(unittest.TestCase):
         self.assertTileEquals(TileRequest(12, 637, 936, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 2, 'json'), 1)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 1, 'json'), 2)
         self.assertTileEquals(TileRequest(11, 318, 468, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(1, 1, 0, 1, 'json'), offset)
 
@@ -47,7 +47,7 @@ class MetatileTestCase(unittest.TestCase):
         self.assertTileEquals(TileRequest(12, 637, 936, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 935, 8, 'json'), 1)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 935, 1, 'json'), 8)
         self.assertTileEquals(TileRequest(9, 79, 116, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(3, 5, 7, 1, 'json'), offset)
 
@@ -59,7 +59,7 @@ class MetatileTestCase(unittest.TestCase):
         # check that when the metatile would be smaller than the world (i.e:
         # zoom < 0) then it just stops at 0 and we get the offset to the 0/0/0
         # tile.
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 2, 'json'), 1)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 2)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
@@ -70,7 +70,7 @@ class MetatileTestCase(unittest.TestCase):
             tile_px, request_z = map(int, request.split("/"))
             tile_size = tile_px // 256
             meta, offset = meta_and_offset(
-                TileRequest(request_z, 0, 0, 4, 'json'), tile_size,
+                TileRequest(request_z, 0, 0, tile_size, 'json'), 4,
                 metatile_max_detail_zoom=14)
             self.assertTileEquals(TileRequest(meta_z, 0, 0, 1, 'zip'), meta)
             self.assertTileEquals(TileRequest(offset_z, 0, 0, 1, 'json'), offset)
@@ -109,21 +109,21 @@ class MetatileTestCase(unittest.TestCase):
 
         # check that when the metatile size is larger (e.g: 8), we can still
         # access the low zoom tiles 0-3.
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 8, 'json'), 2)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 2, 'json'), 8)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(1, 0, 1, 8, 'json'), 2)
+        meta, offset = meta_and_offset(TileRequest(1, 0, 1, 2, 'json'), 8)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(1, 0, 1, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(2, 1, 3, 8, 'json'), 2)
+        meta, offset = meta_and_offset(TileRequest(2, 1, 3, 2, 'json'), 8)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(2, 1, 3, 1, 'json'), offset)
 
         # only once the offset exceeds the metatile size (at the request tile
         # size) does it start to shift down zooms.
-        meta, offset = meta_and_offset(TileRequest(3, 2, 7, 8, 'json'), 2)
+        meta, offset = meta_and_offset(TileRequest(3, 2, 7, 2, 'json'), 8)
         self.assertTileEquals(TileRequest(1, 0, 1, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(2, 2, 3, 1, 'json'), offset)
 

--- a/tests.py
+++ b/tests.py
@@ -31,35 +31,35 @@ class MetatileTestCase(unittest.TestCase):
     def test_meta_and_offset(self):
         from server import meta_and_offset
 
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 1, 1)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 1)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 1, 'json'), 1, 1)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 1, 'json'), 1)
         self.assertTileEquals(TileRequest(12, 637, 936, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 1, 'json'), 2, 1)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 2, 'json'), 1)
         self.assertTileEquals(TileRequest(11, 318, 468, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(1, 1, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 1, 'json'), 2, 2)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 2, 'json'), 2)
         self.assertTileEquals(TileRequest(12, 637, 936, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 935, 1, 'json'), 8, 1)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 935, 8, 'json'), 1)
         self.assertTileEquals(TileRequest(9, 79, 116, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(3, 5, 7, 1, 'json'), offset)
 
         # check that the "512px" 0/0/0 tile is accessible.
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 2, 2)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 2, 'json'), 2)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
         # check that when the metatile would be smaller than the world (i.e:
         # zoom < 0) then it just stops at 0 and we get the offset to the 0/0/0
         # tile.
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 2, 1)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 2, 'json'), 1)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
@@ -70,7 +70,7 @@ class MetatileTestCase(unittest.TestCase):
             tile_px, request_z = map(int, request.split("/"))
             tile_size = tile_px // 256
             meta, offset = meta_and_offset(
-                TileRequest(request_z, 0, 0, 1, 'json'), 4, tile_size,
+                TileRequest(request_z, 0, 0, 4, 'json'), tile_size,
                 metatile_max_detail_zoom=14)
             self.assertTileEquals(TileRequest(meta_z, 0, 0, 1, 'zip'), meta)
             self.assertTileEquals(TileRequest(offset_z, 0, 0, 1, 'json'), offset)
@@ -100,7 +100,7 @@ class MetatileTestCase(unittest.TestCase):
 
         # check that passing None (the default) as the max detail zoom
         # disables this behaviour.
-        meta, offset = meta_and_offset(TileRequest(16, 0, 0, 1, 'json'), 4, 4)
+        meta, offset = meta_and_offset(TileRequest(16, 0, 0, 4, 'json'), 4)
         self.assertTileEquals(TileRequest(16, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
@@ -109,21 +109,21 @@ class MetatileTestCase(unittest.TestCase):
 
         # check that when the metatile size is larger (e.g: 8), we can still
         # access the low zoom tiles 0-3.
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 8, 2)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 8, 'json'), 2)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(1, 0, 1, 1, 'json'), 8, 2)
+        meta, offset = meta_and_offset(TileRequest(1, 0, 1, 8, 'json'), 2)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(1, 0, 1, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(2, 1, 3, 1, 'json'), 8, 2)
+        meta, offset = meta_and_offset(TileRequest(2, 1, 3, 8, 'json'), 2)
         self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(2, 1, 3, 1, 'json'), offset)
 
         # only once the offset exceeds the metatile size (at the request tile
         # size) does it start to shift down zooms.
-        meta, offset = meta_and_offset(TileRequest(3, 2, 7, 1, 'json'), 8, 2)
+        meta, offset = meta_and_offset(TileRequest(3, 2, 7, 8, 'json'), 2)
         self.assertTileEquals(TileRequest(1, 0, 1, 1, 'zip'), meta)
         self.assertTileEquals(TileRequest(2, 2, 3, 1, 'json'), offset)
 

--- a/tests.py
+++ b/tests.py
@@ -31,37 +31,37 @@ class MetatileTestCase(unittest.TestCase):
     def test_meta_and_offset(self):
         from server import meta_and_offset
 
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 'json'), 1, 1)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 1, 1)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 'json'), 1, 1)
-        self.assertTileEquals(TileRequest(12, 637, 936, 'zip'), meta)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 1, 'json'), 1, 1)
+        self.assertTileEquals(TileRequest(12, 637, 936, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 'json'), 2, 1)
-        self.assertTileEquals(TileRequest(11, 318, 468, 'zip'), meta)
-        self.assertTileEquals(TileRequest(1, 1, 0, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 1, 'json'), 2, 1)
+        self.assertTileEquals(TileRequest(11, 318, 468, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(1, 1, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 'json'), 2, 2)
-        self.assertTileEquals(TileRequest(12, 637, 936, 'zip'), meta)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 936, 1, 'json'), 2, 2)
+        self.assertTileEquals(TileRequest(12, 637, 936, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(12, 637, 935, 'json'), 8, 1)
-        self.assertTileEquals(TileRequest(9, 79, 116, 'zip'), meta)
-        self.assertTileEquals(TileRequest(3, 5, 7, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(12, 637, 935, 1, 'json'), 8, 1)
+        self.assertTileEquals(TileRequest(9, 79, 116, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(3, 5, 7, 1, 'json'), offset)
 
         # check that the "512px" 0/0/0 tile is accessible.
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 'json'), 2, 2)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 2, 2)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
         # check that when the metatile would be smaller than the world (i.e:
         # zoom < 0) then it just stops at 0 and we get the offset to the 0/0/0
         # tile.
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 'json'), 2, 1)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 2, 1)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
     def test_max_detail_zoom(self):
         from server import meta_and_offset
@@ -70,10 +70,10 @@ class MetatileTestCase(unittest.TestCase):
             tile_px, request_z = map(int, request.split("/"))
             tile_size = tile_px // 256
             meta, offset = meta_and_offset(
-                TileRequest(request_z, 0, 0, 'json'), 4, tile_size,
+                TileRequest(request_z, 0, 0, 1, 'json'), 4, tile_size,
                 metatile_max_detail_zoom=14)
-            self.assertTileEquals(TileRequest(meta_z, 0, 0, 'zip'), meta)
-            self.assertTileEquals(TileRequest(offset_z, 0, 0, 'json'), offset)
+            self.assertTileEquals(TileRequest(meta_z, 0, 0, 1, 'zip'), meta)
+            self.assertTileEquals(TileRequest(offset_z, 0, 0, 1, 'json'), offset)
 
         # check that when the requested tile is past the max level of detail,
         # then it falls back to "smaller" tiles.
@@ -100,32 +100,32 @@ class MetatileTestCase(unittest.TestCase):
 
         # check that passing None (the default) as the max detail zoom
         # disables this behaviour.
-        meta, offset = meta_and_offset(TileRequest(16, 0, 0, 'json'), 4, 4)
-        self.assertTileEquals(TileRequest(16, 0, 0, 'zip'), meta)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(16, 0, 0, 1, 'json'), 4, 4)
+        self.assertTileEquals(TileRequest(16, 0, 0, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
     def test_zoom_zero(self):
         from server import meta_and_offset
 
         # check that when the metatile size is larger (e.g: 8), we can still
         # access the low zoom tiles 0-3.
-        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 'json'), 8, 2)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(0, 0, 0, 1, 'json'), 8, 2)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(1, 0, 1, 'json'), 8, 2)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
-        self.assertTileEquals(TileRequest(1, 0, 1, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(1, 0, 1, 1, 'json'), 8, 2)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(1, 0, 1, 1, 'json'), offset)
 
-        meta, offset = meta_and_offset(TileRequest(2, 1, 3, 'json'), 8, 2)
-        self.assertTileEquals(TileRequest(0, 0, 0, 'zip'), meta)
-        self.assertTileEquals(TileRequest(2, 1, 3, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(2, 1, 3, 1, 'json'), 8, 2)
+        self.assertTileEquals(TileRequest(0, 0, 0, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(2, 1, 3, 1, 'json'), offset)
 
         # only once the offset exceeds the metatile size (at the request tile
         # size) does it start to shift down zooms.
-        meta, offset = meta_and_offset(TileRequest(3, 2, 7, 'json'), 8, 2)
-        self.assertTileEquals(TileRequest(1, 0, 1, 'zip'), meta)
-        self.assertTileEquals(TileRequest(2, 2, 3, 'json'), offset)
+        meta, offset = meta_and_offset(TileRequest(3, 2, 7, 1, 'json'), 8, 2)
+        self.assertTileEquals(TileRequest(1, 0, 1, 1, 'zip'), meta)
+        self.assertTileEquals(TileRequest(2, 2, 3, 1, 'json'), offset)
 
     def test_valid_tile_request(self):
         from server import is_valid_tile_request
@@ -152,7 +152,7 @@ class MetatileTestCase(unittest.TestCase):
     def test_compute_key(self):
         from server import compute_key, KeyFormatType
 
-        t = TileRequest(13, 4008, 3973, 'zip')
+        t = TileRequest(13, 4008, 3973, 1, 'zip')
 
         self.assertEqual(
             'abc/c1315/all/13/4008/3973.zip',
@@ -169,7 +169,7 @@ class MetatileTestCase(unittest.TestCase):
 
         # test for "new format" hashed path where layer isn't included
         # since https://github.com/tilezen/tilequeue/pull/344
-        t2 = TileRequest(10, 14, 719, 'zip')
+        t2 = TileRequest(10, 14, 719, 1, 'zip')
         self.assertEqual(
             '27584/180723/10/14/719.zip',
             compute_key('180723', '', t2, KeyFormatType.HASH_PREFIX))


### PR DESCRIPTION
This is a rough sketch that adds support for [tapalcatl2](https://github.com/mojodna/tapalcatl-2-spec) archives for a new landcover layer.

Since tapalcatl-py's "metatile" format and "tapalcatl2 archives" are incompatible, it's pretty tricky to gracefully add support for this in tapalcatl-py. I'd appreciate some feedback on that aspect of it.

It feels like we might be better served writing a separate app that more gracefully handles the "tapalcatl2 archive" format. It'd be very quick to do – just a copy/paste of tapalcatl-py that only uses the tapalcatl2 pieces and exposes them more appropriately via configuration.